### PR TITLE
Switch to universal-ctags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
             build-essential \
             ca-certificates \
             curl \
-            exuberant-ctags \
+            universal-ctags \
             gfortran \
             git \
             libhwloc-dev \
@@ -48,11 +48,11 @@ jobs:
         run: |
           brew install \
             curl \
-            ctags-exuberant \
             gawk \
             gnu-sed \
             hwloc \
-            pkg-config
+            pkg-config \
+            universal-ctags
       - uses: actions/setup-python@v5.0.0
         with:
           python-version: ${{ matrix.python-version }}

--- a/BifrostDemo.ipynb
+++ b/BifrostDemo.ipynb
@@ -43,7 +43,7 @@
         "# @title Install C++ deps\n",
         "%%shell\n",
         "\n",
-        "sudo apt-get -qq install exuberant-ctags libopenblas-dev software-properties-common build-essential"
+        "sudo apt-get -qq install universal-ctags libopenblas-dev software-properties-common build-essential"
       ]
     },
     {

--- a/README.md
+++ b/README.md
@@ -105,7 +105,11 @@ in the docs to see which versions of the CUDA toolkit have been confirmed to wor
 
 If using Ubuntu or another Debian-based linux distribution:
     
-    $ sudo apt-get install exuberant-ctags
+    $ sudo apt-get install universal-ctags
+
+If using Redhat or another Redhat-based linux distribution:
+
+    $ sudo dnf install ctags
 
 Otherwise check https://ctags.sourceforge.net/ for install instructions.
 

--- a/configure
+++ b/configure
@@ -17662,12 +17662,12 @@ then :
   as_fn_error $? "Required program ctags was not found" "$LINENO" 5
 fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether ${CTAGS} is exuberant" >&5
-printf %s "checking whether ${CTAGS} is exuberant... " >&6; }
+printf %s "checking whether ${CTAGS} is sufficiently exuberant... " >&6; }
 if ! ${CTAGS} --version | grep -q Exuberant
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }
-       as_fn_error $? "exuberant ctags is required, but ${CTAGS} is a different version" "$LINENO" 5
+       as_fn_error $? "exuberant/universal ctags is required, but ${CTAGS} is a different version" "$LINENO" 5
 else $as_nop
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -26,10 +26,10 @@ AX_WITH_PROG(CTAGS, ctags)
 AS_IF([test x${CTAGS} = x],
       [AC_MSG_ERROR([Required program ctags was not found])],
       [])
-AC_MSG_CHECKING([whether ${CTAGS} is exuberant])
+AC_MSG_CHECKING([whether ${CTAGS} is sufficiently exuberant])
 AS_IF([! ${CTAGS} --version | grep -q Exuberant],
       [AC_MSG_RESULT([no])
-       AC_MSG_ERROR([exuberant ctags is required, but ${CTAGS} is a different version])],
+       AC_MSG_ERROR([exuberant/universal ctags is required, but ${CTAGS} is a different version])],
       [AC_MSG_RESULT([yes])])
 
 AC_SUBST(SO_EXT, $shrext_cmds)

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -5,7 +5,7 @@ build:
   apt_packages:
     - autoconf
     - doxygen
-    - exuberant-ctags
+    - universal-ctags
     - gawk
     - gfortran
     - grep

--- a/docs/source/Getting-started-guide.rst
+++ b/docs/source/Getting-started-guide.rst
@@ -93,11 +93,11 @@ has been tested against.
 Other Dependencies
 ^^^^^^^^^^^^^^^^^^
 
-- exuberant-ctags
+- universal-ctags
 - Basic build tools (make, gcc, etc.)
 
 On Ubuntu, the following command should grab everything you need: 
-    ``sudo apt-get install build-essential software-properties-common exuberant-ctags``
+    ``sudo apt-get install build-essential software-properties-common universal-ctags``
 
 Bifrost install
 ~~~~~~~~~~~~~~~

--- a/tutorial/00_getting_started.ipynb
+++ b/tutorial/00_getting_started.ipynb
@@ -37,7 +37,7 @@
         "except ModuleNotFoundError:\n",
         "  try:\n",
         "    import google.colab\n",
-        "    !sudo apt-get -qq install exuberant-ctags libopenblas-dev software-properties-common build-essential\n",
+        "    !sudo apt-get -qq install universal-ctags libopenblas-dev software-properties-common build-essential\n",
         "    !pip install -q contextlib2 pint simplejson scipy ctypesgen==1.0.2\n",
         "    ![ -d ~/bifrost/.git ] || git clone https://github.com/ledatelescope/bifrost ~/bifrost\n",
         "    !(cd ~/bifrost && ./configure && make -j all && sudo make install)\n",

--- a/tutorial/01_useful_functions.ipynb
+++ b/tutorial/01_useful_functions.ipynb
@@ -39,7 +39,7 @@
         "except ModuleNotFoundError:\n",
         "  try:\n",
         "    import google.colab\n",
-        "    !sudo apt-get -qq install exuberant-ctags libopenblas-dev software-properties-common build-essential\n",
+        "    !sudo apt-get -qq install universal-ctags libopenblas-dev software-properties-common build-essential\n",
         "    !pip install -q contextlib2 pint simplejson scipy git+https://github.com/ctypesgen/ctypesgen.git\n",
         "    ![ -d ~/bifrost/.git ] || git clone https://github.com/ledatelescope/bifrost ~/bifrost\n",
         "    !(cd ~/bifrost && ./configure && make -j all && sudo make install)\n",

--- a/tutorial/02_building_complexity.ipynb
+++ b/tutorial/02_building_complexity.ipynb
@@ -27,7 +27,7 @@
         "except ModuleNotFoundError:\n",
         "  try:\n",
         "    import google.colab\n",
-        "    !sudo apt-get -qq install exuberant-ctags libopenblas-dev software-properties-common build-essential\n",
+        "    !sudo apt-get -qq install universal-ctags libopenblas-dev software-properties-common build-essential\n",
         "    !pip install -q contextlib2 pint simplejson scipy git+https://github.com/ctypesgen/ctypesgen.git\n",
         "    ![ -d ~/bifrost/.git ] || git clone https://github.com/ledatelescope/bifrost ~/bifrost\n",
         "    !(cd ~/bifrost && ./configure && make -j all && sudo make install)\n",

--- a/tutorial/03_putting_it_together.ipynb
+++ b/tutorial/03_putting_it_together.ipynb
@@ -26,7 +26,7 @@
         "except ModuleNotFoundError:\n",
         "  try:\n",
         "    import google.colab\n",
-        "    !sudo apt-get -qq install exuberant-ctags libopenblas-dev software-properties-common build-essential\n",
+        "    !sudo apt-get -qq install universal-ctags libopenblas-dev software-properties-common build-essential\n",
         "    !pip install -q contextlib2 pint simplejson scipy git+https://github.com/ctypesgen/ctypesgen.git\n",
         "    ![ -d ~/bifrost/.git ] || git clone https://github.com/ledatelescope/bifrost ~/bifrost\n",
         "    !(cd ~/bifrost && ./configure && make -j all && sudo make install)\n",

--- a/tutorial/04_pipelines.ipynb
+++ b/tutorial/04_pipelines.ipynb
@@ -28,7 +28,7 @@
         "    import google.colab\n",
         "  except ModuleNotFoundError:\n",
         "    raise exn\n",
-        "  !sudo apt-get -qq install exuberant-ctags libopenblas-dev software-properties-common build-essential\n",
+        "  !sudo apt-get -qq install universal-ctags libopenblas-dev software-properties-common build-essential\n",
         "  !pip install -q contextlib2 pint simplejson scipy git+https://github.com/ctypesgen/ctypesgen.git\n",
         "  ![ -d ~/bifrost/.git ] || git clone https://github.com/ledatelescope/bifrost ~/bifrost\n",
         "  !(cd ~/bifrost && ./configure --disable-cuda && make -j all && sudo make install)\n",

--- a/tutorial/05_block_logging.ipynb
+++ b/tutorial/05_block_logging.ipynb
@@ -28,7 +28,7 @@
         "    import google.colab\n",
         "  except ModuleNotFoundError:\n",
         "    raise exn\n",
-        "  !sudo apt-get -qq install exuberant-ctags libopenblas-dev software-properties-common build-essential\n",
+        "  !sudo apt-get -qq install universal-ctags libopenblas-dev software-properties-common build-essential\n",
         "  !pip install -q contextlib2 pint simplejson scipy git+https://github.com/ctypesgen/ctypesgen.git\n",
         "  ![ -d ~/bifrost/.git ] || git clone https://github.com/ledatelescope/bifrost ~/bifrost\n",
         "  !(cd ~/bifrost && ./configure --disable-cuda && make -j all && sudo make install)\n",

--- a/tutorial/06_data_capture.ipynb
+++ b/tutorial/06_data_capture.ipynb
@@ -29,7 +29,7 @@
         "    import google.colab\n",
         "  except ModuleNotFoundError:\n",
         "    raise exn\n",
-        "  !sudo apt-get -qq install exuberant-ctags libopenblas-dev librdmacm-dev software-properties-common build-essential\n",
+        "  !sudo apt-get -qq install universal-ctags libopenblas-dev librdmacm-dev software-properties-common build-essential\n",
         "  !pip install -q contextlib2 pint simplejson scipy git+https://github.com/ctypesgen/ctypesgen.git\n",
         "  ![ -d ~/bifrost/.git ] || git clone https://github.com/ledatelescope/bifrost ~/bifrost\n",
         "  !(cd ~/bifrost && ./configure --disable-hwloc && make -j all && sudo make install)\n",

--- a/tutorial/07_high_level_api.ipynb
+++ b/tutorial/07_high_level_api.ipynb
@@ -51,7 +51,7 @@
         "    import google.colab\n",
         "  except ModuleNotFoundError:\n",
         "    raise exn\n",
-        "  !sudo apt-get -qq install exuberant-ctags libopenblas-dev software-properties-common build-essential\n",
+        "  !sudo apt-get -qq install universal-ctags libopenblas-dev software-properties-common build-essential\n",
         "  !pip install -q contextlib2 pint simplejson scipy git+https://github.com/ctypesgen/ctypesgen.git\n",
         "  ![ -d ~/bifrost/.git ] || git clone https://github.com/ledatelescope/bifrost ~/bifrost\n",
         "  !(cd ~/bifrost && ./configure --disable-cuda && make -j all && sudo make install)\n",


### PR DESCRIPTION
Fixes #246 at some level.

This PR moves over to using universal-ctags.  This seems to be a successor to exuberant-ctags that is available on Ubuntu, home brew, and Redhat-based system.

Things left to do:
- [x] Update `configure` so that it isn't explicitly tied to exuberant-ctags
- [x] Update the documentation
- [x] Update `flake.nix`
- [ ] Update the Dockerfiles (also see #215)
- [x] Make sure the tutorial still runs on Google Colab